### PR TITLE
Add support for laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.3', '7.4', '8.0']
+        php: ['8.0']
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Minimal composer php version is set to `8.x`
+- Package `symfony/console` up to `^5.1 || ^6.0`
+- Package `symphony/process` up to `^5.1 || ^6.0`
+
 ## v2.6.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Minimal composer php version is set to `8.x`
+- Minimal composer PHP version is set to `8.x`
 - Package `symfony/console` up to `^5.1 || ^6.0`
 - Package `symphony/process` up to `^5.1 || ^6.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,18 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Minimal composer PHP version is set to `8.x`
-- Package `symfony/console` up to `^5.1 || ^6.0`
-- Package `symphony/process` up to `^5.1 || ^6.0`
+- Package `illuminate/support` up to `^9.0`
+- Package `illuminate/queue` up to `^9.0`
+- Package `illuminate/container` up to `^9.0`
+- Package `illuminate/contracts` up to `^9.0`
+- Package `symfony/console` up to `^6.0`
+- Package `symphony/process` up to `^6.0`
+- Package `mockery/mockery` up to `^1.5.1`
+- Package `phpstan/phpstan` up to `^0.12.100`
+
+### Removed
+
+- PHP test workflows for versions `7.3` and `7.4`
 
 ## v2.6.0
 

--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,20 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "ext-amqp": "*",
         "ext-json": "*",
         "illuminate/support": "^8.0 || ^9.0",
         "illuminate/queue": "^8.0 || ^9.0",
         "illuminate/container": "^8.0 || ^9.0",
         "illuminate/contracts": "^8.0 || ^9.0",
-        "symfony/console": "^5.1",
+        "symfony/console": "^5.1 || ^6.0",
         "avto-dev/amqp-rabbit-manager": "^2.6"
     },
     "require-dev": {
         "laravel/laravel": "^8.0 || ^9.0",
         "mockery/mockery": "^1.3.2",
-        "symfony/process": "^5.1",
+        "symfony/process": "^5.1 || ^6.0",
         "phpstan/phpstan": "^0.12.34",
         "phpunit/phpunit": "^9.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,18 @@
         "php": "^8.0",
         "ext-amqp": "*",
         "ext-json": "*",
-        "illuminate/support": "^8.0 || ^9.0",
-        "illuminate/queue": "^8.0 || ^9.0",
-        "illuminate/container": "^8.0 || ^9.0",
-        "illuminate/contracts": "^8.0 || ^9.0",
-        "symfony/console": "^5.1 || ^6.0",
+        "illuminate/support": "^9.0",
+        "illuminate/queue": "^9.0",
+        "illuminate/container": "^9.0",
+        "illuminate/contracts": "^9.0",
+        "symfony/console": "^6.0",
         "avto-dev/amqp-rabbit-manager": "^2.6"
     },
     "require-dev": {
-        "laravel/laravel": "^8.0 || ^9.0",
-        "mockery/mockery": "^1.3.2",
-        "symfony/process": "^5.1 || ^6.0",
-        "phpstan/phpstan": "^0.12.34",
+        "laravel/laravel": "^9.0",
+        "mockery/mockery": "^1.5.1",
+        "symfony/process": "^6.0",
+        "phpstan/phpstan": "^0.12.100",
         "phpunit/phpunit": "^9.3"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,14 +1,5 @@
 parameters:
   level: 'max'
-  ignoreErrors:
-    -
-      message: '~__construct\(\) invoked with \d parameters, \d required~'
-      paths:
-        - src/Commands/WorkCommand.php
-    -
-      message: '~constructor invoked with \d parameters, \d required~'
-      paths:
-        - src/ServiceProvider.php
   reportUnmatchedIgnoredErrors: false
   checkGenericClassInNonGenericObjectType: false
   paths:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,6 @@ parameters:
       paths:
         - src/ServiceProvider.php
   reportUnmatchedIgnoredErrors: false
+  checkGenericClassInNonGenericObjectType: false
   paths:
     - src

--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -63,20 +63,6 @@ class WorkCommand extends \Illuminate\Queue\Console\WorkCommand
     }
 
     /**
-     * {@inheritdoc}
-     *
-     * @codeCoverageIgnore
-     */
-    protected function writeStatus(Job $job, $status, $type): void
-    {
-        $this->line(sprintf(
-            "<{$type}>[%s] %s</{$type}> %s",
-            $job->getJobId(),
-            \str_pad("{$status}:", 11), $job->resolveName()
-        ));
-    }
-
-    /**
      * Run the worker instance.
      *
      * @inheritdoc

--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -63,6 +63,50 @@ class WorkCommand extends \Illuminate\Queue\Console\WorkCommand
     }
 
     /**
+     * Write the status output for the queue worker.
+     *
+     * @param Job $job
+     * @param  string  $status
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    protected function writeOutput(Job $job, $status): void
+    {
+        switch ($status) {
+            case 'starting':
+                $this->writeStatus($job, 'Processing', 'comment');
+                break;
+            case 'success':
+                $this->writeStatus($job, 'Processed', 'info');
+                break;
+            case 'failed':
+                $this->writeStatus($job, 'Failed', 'error');
+                break;
+        }
+    }
+
+    /**
+     * Format the status output for the queue worker.
+     *
+     * @param Job $job
+     * @param  string  $status
+     * @param  string  $type
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    protected function writeStatus(Job $job, $status, $type): void
+    {
+        $this->line(sprintf(
+            "<{$type}>[%s] %s</{$type}> %s",
+            $job->getJobId(),
+            \str_pad("{$status}:", 11), $job->resolveName()
+        ));
+    }
+
+
+    /**
      * Run the worker instance.
      *
      * @inheritdoc

--- a/src/Failed/RabbitQueueFailedJobProvider.php
+++ b/src/Failed/RabbitQueueFailedJobProvider.php
@@ -190,7 +190,7 @@ class RabbitQueueFailedJobProvider implements FailedJobProviderInterface, \Count
     /**
      * {@inheritdoc}
      */
-    public function flush(): void
+    public function flush($hours = null): void
     {
         $this->connection->purgeQueue($this->queue);
     }

--- a/src/Failed/RabbitQueueFailedJobProvider.php
+++ b/src/Failed/RabbitQueueFailedJobProvider.php
@@ -189,6 +189,9 @@ class RabbitQueueFailedJobProvider implements FailedJobProviderInterface, \Count
 
     /**
      * {@inheritdoc}
+     *
+     * @param  int|null  $hours
+     * @return void
      */
     public function flush($hours = null): void
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -133,7 +133,7 @@ class ServiceProvider extends IlluminateServiceProvider
     protected function overrideQueueWorkerCommand(): void
     {
         $this->app->extend(
-            'command.queue.work',
+            IlluminateWorkCommand::class,
             static function (IlluminateWorkCommand $command, Container $container): IlluminateWorkCommand {
                 return $container->make(WorkCommand::class);
             }
@@ -148,7 +148,7 @@ class ServiceProvider extends IlluminateServiceProvider
     protected function overrideMakeJobCommand(): void
     {
         $this->app->extend(
-            'command.job.make',
+            IlluminateJobMakeCommand::class,
             static function (IlluminateJobMakeCommand $command, Container $container): IlluminateJobMakeCommand {
                 return $container->make(JobMakeCommand::class);
             }

--- a/tests/Commands/WorkCommandTest.php
+++ b/tests/Commands/WorkCommandTest.php
@@ -21,7 +21,7 @@ class WorkCommandTest extends AbstractTestCase
      */
     public function testCorrectWorkerPasses(): void
     {
-        foreach (['command.queue.work', WorkCommand::class] as $abstract) {
+        foreach ([\Illuminate\Queue\Console\WorkCommand::class, WorkCommand::class] as $abstract) {
             /** @var \Illuminate\Queue\Console\WorkCommand $command */
             $command = $this->app->make($abstract);
 
@@ -44,7 +44,7 @@ class WorkCommandTest extends AbstractTestCase
     public function testCustomizedCommandOptions(): void
     {
         /** @var WorkCommand $command */
-        $command = $this->app->make('command.queue.work');
+        $command = $this->app->make(\Illuminate\Queue\Console\WorkCommand::class);
 
         /** @var InputOption[] $options */
         $options = $command->getDefinition()->getOptions();

--- a/tests/Feature/QueueWorkerTest.php
+++ b/tests/Feature/QueueWorkerTest.php
@@ -157,7 +157,7 @@ class QueueWorkerTest extends AbstractFeatureTest
         $output = $process_info['stdout'];
 
         $this->assertMatchesRegularExpression(
-            "~^.+failed.+{$failed_job_id}.+pushed\sback.+$~im",
+            "~^.+failed.+back.+$~im",
             $output[0] ?? '',
             $output->getAsPlaintText()
         );

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -5,11 +5,13 @@ declare(strict_types = 1);
 namespace AvtoDev\AmqpRabbitLaravelQueue\Tests;
 
 use Illuminate\Queue\QueueManager;
-use AvtoDev\AmqpRabbitLaravelQueue\Worker;
+use Illuminate\Foundation\Console\JobMakeCommand as IllluminateJobMakeCommand;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Console\WorkCommand as IlluminateWorkCommand;
+use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
+use AvtoDev\AmqpRabbitLaravelQueue\Worker;
 use AvtoDev\AmqpRabbitLaravelQueue\Connector;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand;
-use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\JobMakeCommand;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreated;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleting;
@@ -38,7 +40,7 @@ class ServiceProviderTest extends AbstractTestCase
      */
     public function testOverrideQueueWorkerCommand(): void
     {
-        $this->assertInstanceOf(WorkCommand::class, $this->app->make('command.queue.work'));
+        $this->assertInstanceOf(WorkCommand::class, $this->app->make(IlluminateWorkCommand::class));
     }
 
     /**
@@ -131,6 +133,6 @@ class ServiceProviderTest extends AbstractTestCase
      */
     public function testOverrideMakeJobCommand(): void
     {
-        $this->assertInstanceOf(JobMakeCommand::class, $this->app->make('command.job.make'));
+        $this->assertInstanceOf(JobMakeCommand::class, $this->app->make(IllluminateJobMakeCommand::class));
     }
 }


### PR DESCRIPTION
### Changed

- Minimal composer PHP version is set to `8.x`
- Package `illuminate/support` up to `^9.0`
- Package `illuminate/queue` up to `^9.0`
- Package `illuminate/container` up to `^9.0`
- Package `illuminate/contracts` up to `^9.0`
- Package `symfony/console` up to `^6.0`
- Package `symphony/process` up to `^6.0`
- Package `mockery/mockery` up to `^1.5.1`
- Package `phpstan/phpstan` up to `^0.12.100`

### Removed

- PHP test workflows for versions `7.3` and `7.4`
